### PR TITLE
fix(): Add CODEOWNERS file to repo with CloudOps as owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rewindio/devops


### PR DESCRIPTION
# Jira: [Add CODEOWNERS file to repo with CloudOps as owners](https://rewind.atlassian.net/browse/DEVOPS-2228)


# Description of Change
Ensure all action workflow repos has a valid CODEOWNERS file so that reviews from relevant teams are enforced.